### PR TITLE
Set full name of kernel image in QB_DEFAULT_KERNEL to avoid picking D…

### DIFF
--- a/conf/machine/cavium-thunderx.conf
+++ b/conf/machine/cavium-thunderx.conf
@@ -16,6 +16,7 @@ QB_SYSTEM_NAME = "qemu-system-aarch64"
 QB_MEM = "-m 512"
 QB_MACHINE = "-machine virt"
 QB_CPU = "-cpu cortex-a57"
+QB_DEFAULT_KERNEL = "${KERNEL_IMAGETYPE}-cavium-thunderx.bin"
 QB_KERNEL_CMDLINE_APPEND = "console=ttyAMA0,38400"
 # Add the 'virtio-rng-pci' device otherwise the guest may run out of entropy
 QB_OPT_APPEND = "-show-cursor -device virtio-rng-pci -monitor null"


### PR DESCRIPTION
…TB as kernel image

Source: MontaVista Software, LLC
MR: 93497
Type: Defect Fix
Disposition: Local
ChangeID: 7f2ba3c5a5f4ae11c5bb26a4547b86d4538bbe84
Description:
It solves below hang issue:

-- snip --
runqemu cavium-thunderx nographic slirp
runqemu - INFO - Running MACHINE=cavium-thunderx bitbake -e...
runqemu - INFO - Continuing with the following parameters:

KERNEL: [/opt/work_jagadeesh/cavium-thunderx-build-180403132729/project/tmp/deploy/images/cavium-thunderx/Image--4.14.3+git0+9a174c5aee-r0-thunder-88xx-20180322090825.dtb]
MACHINE: [cavium-thunderx]
FSTYPE: [ext4]
ROOTFS: [/opt/work_jagadeesh/cavium-thunderx-build-180403132729/project/tmp/deploy/images/cavium-thunderx/core-image-minimal-cavium-thunderx-20180403130732.rootfs.ext4]
CONFFILE: [/opt/work_jagadeesh/cavium-thunderx-build-180403132729/project/tmp/deploy/images/cavium-thunderx/core-image-minimal-cavium-thunderx-20180403130732.qemuboot.conf]

runqemu - INFO - Port forward: hostfwd=tcp::2222-:22 hostfwd=tcp::2323-:23
runqemu - INFO - Running /opt/work_jagadeesh/cavium-thunderx-build-180403132729/project/tmp/work/x86_64-linux/qemu-helper-native/1.0-r1/recipe-sysroot-native/usr/bin/qemu-system-aarch64 -device virtio-net-device,netdev=net0,mac=52:54:00:12:35:02 -netdev
user,id=net0,hostfwd=tcp::2222-:22,hostfwd=tcp::2323-:23,tftp=/opt/work_jagadeesh/cavium-thunderx-build-180403132729/project/tmp/deploy/images/cavium-thunderx -drive id=disk0,file=/opt/work_jagadeesh/cavium-thunderx-build-180403132729/project/tmp/deploy/images/cavium-thunderx/core-image-minimal-cavium-thunderx-20180403130732.rootfs.ext4,if=none,format=raw -device virtio-blk-device,drive=disk0 -show-cursor -device virtio-rng-pci -monitor null  -nographic -machine virt -cpu cortex-a57 -m 512 -serial mon:stdio -serial null -kernel /opt/work_jagadeesh/cavium-thunderx-build-180403132729/project/tmp/deploy/images/cavium-thunderx/Image--4.14.3+git0+9a174c5aee-r0-thunder-88xx-20180322090825.dtb -append 'root=/dev/vda rw highres=off  console=ttyS0 mem=512M ip=dhcp console=ttyAMA0,38400 '

-- snip --

Signed-off-by: Jagadeesh Krishnanjanappa <jkrishnanjanappa@mvista.com>